### PR TITLE
Improve BINDING_TRANSFORMS warning

### DIFF
--- a/packages/ember-metal/lib/binding.js
+++ b/packages/ember-metal/lib/binding.js
@@ -303,8 +303,10 @@ Binding.prototype = /** @scope Ember.Binding.prototype */ {
     @returns {Ember.Binding} this
   */
   transform: function(transform) {
-    var op = {warn: Ember.deprecate, '1.0': Ember.assert}[Ember.ENV.BINDING_TRANSFORMS] || Ember.K;
-    op("Binding transforms have been removed from Ember 1.0.");
+    var op = {warn: Ember.deprecate, '1.0': Ember.assert}[Ember.ENV.BINDING_TRANSFORMS] || Ember.K,
+        message = "Binding transforms have been removed from Ember 1.0. (" +
+                    this._from + " -> " + this._to + ")";
+    op(message);
 
     if ('function' === typeof transform) {
       transform = { to: transform };

--- a/packages/ember-metal/tests/backports/binding_transforms_test.js
+++ b/packages/ember-metal/tests/backports/binding_transforms_test.js
@@ -23,7 +23,7 @@ test("warns on usage of Binding#transform in warn level", function() {
   Ember.ENV.BINDING_TRANSFORMS = 'warn';
   new Ember.Binding('foo.value', 'bar.value').transform({ from: function() {}, to: function() {} });
   equal(warnings.length, 1);
-  matches(warnings[0], "Binding transforms have been removed from Ember 1.0.");
+  matches(warnings[0], "Binding transforms have been removed from Ember 1.0. (bar.value -> foo.value)");
 });
 
 test("throws on usage of Binding#transform in 1.0 level", function() {


### PR DESCRIPTION
@shajith @jish 

Old message:

> Binding transforms have been removed from Ember 1.0.

New message:

> Binding transforms have been removed from Ember 1.0. (foo.name -> name)
