### PR TITLE
Add support for per-class view-context-preservation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ app more and more Ember-1.0-compatible.
  * [Ember.ViewState](doc/view_state.md)
  * [Ember.Evented#fire](doc/evented_fire.md)
  * [Binding transforms](doc/binding_transforms.md)
+ * [View Preserves Context](doc/view_preserves_context.md)

--- a/doc/view_preserves_context.md
+++ b/doc/view_preserves_context.md
@@ -1,0 +1,63 @@
+# View Preserves Context
+
+In Ember 0.9.7.1, the context for a view's template is the view itself.
+
+In Ember 1.0, it is the parent view's context, which, if you follow it all the
+way up the chain, is usually a controller.
+
+Ember 0.9.8.1 introduced a global flag, `VIEW_PRESERVES_CONTEXT`, which allows
+application developers to select which behavior they want. Unfortunately, a
+global flag is often insufficient for large applications, which cannot upgrade
+all at once.
+
+Ember 0.9.9 adds support for view classes to define a class-level
+`preservesContext` property that overrides the flag. It also adds a new value
+for the flag, "warn", which will warn for any view that *doesn't* declare that
+it preserves context. If `VIEW_PRESERVES_CONTEXT` is `true`, it cannot be
+overridden.
+
+## Summary
+
+| `VIEW_PRESERVES_CONTEXT` | `preservesContext` | preserves context? | extra  |
+|--------------------------|--------------------|--------------------|--------|
+| `false`                  | `undefined`        | no                 |        |
+| `false`                  | `false`            | no                 |        |
+| `false`                  | `true`             | yes                |        |
+| `"warn"`                 | `undefined`        | no                 | warns  |
+| `"warn"`                 | `false`            | no                 | warns  |
+| `"warn"`                 | `true`             | yes                |        |
+| `true`                   | `undefined`        | yes                |        |
+| `true`                   | `false`            | n/a                | throws |
+| `true`                   | `true`             | yes                |        |
+
+## Upgrade Guide
+
+First, set `VIEW_PRESERVES_CONTEXT` to `false`; commit that change.
+
+Then, temporarily set `VIEW_PRESERVES_CONTEXT` to `"warn"`. For each view
+class that it warns about, declare that it preserves context:
+
+```javascript
+var MyView = Ember.View.extend({
+  someProperty: function() {
+    return 'some value';
+  }.property()
+}).reopenClass({ preservesContext: true });
+```
+
+If there are properties on `MyView` that you were using in the template,
+you will have to prefix the reference with `view.`:
+
+```handlebars
+{{#view MyView}}
+  The value of someProperty is {{view.someProperty}}
+{{/view}}
+```
+
+Continue to upgrade views, a few at a time. Once you are done or nearly done,
+change `VIEW_PRESERVES_CONTEXT` to "warn" in source control to help find the
+last few.
+
+Once you feel confident that you have upgraded all of your view classes,
+change `VIEW_PRESERVES_CONTEXT` to `true`. At this point, you can remove
+all class-level `preservesContext: true` declarations.

--- a/packages/ember-handlebars/tests/backports/context_preservation_test.js
+++ b/packages/ember-handlebars/tests/backports/context_preservation_test.js
@@ -1,0 +1,96 @@
+/*globals ContextPreservationTests:true*/
+
+var originalFlag, originalWarn, warnings, viewToDestroy;
+
+function appendView(childPreservesContext) {
+  ContextPreservationTests.ChildView.reopenClass({ preservesContext: childPreservesContext });
+  var view = ContextPreservationTests.ParentView.create();
+  Ember.run(function() { view.appendTo('#qunit-fixture'); });
+  viewToDestroy = view;
+  return view;
+}
+
+module("Backported Ember.View Context Preservation", {
+  setup: function() {
+    window.ContextPreservationTests = Ember.Namespace.create();
+    originalFlag = Ember.VIEW_PRESERVES_CONTEXT;
+    originalWarn = Ember.Logger.warn;
+    warnings = [];
+    Ember.Logger.warn = function(msg) {
+      warnings.push(msg.replace("WARNING: ", ""));
+    };
+
+    ContextPreservationTests.parentContext = { key: 'parent view value' };
+
+    ContextPreservationTests.ParentView = Ember.View.extend({
+      template: Ember.Handlebars.compile("{{#with ContextPreservationTests.parentContext}}{{view ContextPreservationTests.ChildView}}{{/with}}")
+    }).reopenClass({ preservesContext: true });
+
+    ContextPreservationTests.ChildView = Ember.View.extend({
+      template: Ember.Handlebars.compile('{{key}}'),
+      key: 'child view value'
+    });
+  },
+
+  teardown: function() {
+    Ember.VIEW_PRESERVES_CONTEXT = originalFlag;
+    Ember.Logger.warn = originalWarn;
+    if (viewToDestroy) {
+      Ember.run(function() {
+        viewToDestroy.destroy();
+      });
+      viewToDestroy = undefined;
+    }
+    window.ContextPreservationTests = undefined;
+  }
+});
+
+test("doesn't warn on false level", function() {
+  Ember.VIEW_PRESERVES_CONTEXT = false;
+  appendView(undefined);
+  equal(warnings.length, 0);
+});
+
+test("uses the view as the context on false level by default", function() {
+  Ember.VIEW_PRESERVES_CONTEXT = false;
+  equal(appendView(undefined).$().text(), "child view value");
+});
+
+test("allows views to specify that they preserve context on false level", function() {
+  Ember.VIEW_PRESERVES_CONTEXT = false;
+  equal(appendView(true).$().text(), "parent view value");
+});
+
+test("warns on 'warn' level for views that don't preserve context", function() {
+  Ember.VIEW_PRESERVES_CONTEXT = "warn";
+  appendView(undefined);
+  equal(warnings.length, 1);
+});
+
+test("doesn't warn on 'warn' level for views that do preserve context", function() {
+  Ember.VIEW_PRESERVES_CONTEXT = "warn";
+  appendView(true);
+  equal(warnings.length, 0);
+});
+
+test("uses the view as the context on 'warn' level by default", function() {
+  Ember.VIEW_PRESERVES_CONTEXT = 'warn';
+  equal(appendView(undefined).$().text(), "child view value");
+});
+
+test("allows views to specify that they preserve context on 'warn' level", function() {
+  Ember.VIEW_PRESERVES_CONTEXT = 'warn';
+  equal(appendView(true).$().text(), "parent view value");
+});
+
+test("preserves context on true level", function() {
+  Ember.VIEW_PRESERVES_CONTEXT = true;
+  equal(appendView(undefined).$().text(), 'parent view value');
+});
+
+test("raises an exception if a view tries to override the default on true level", function() {
+  Ember.VIEW_PRESERVES_CONTEXT = true;
+  raises(function() {
+    appendView(false);
+  }, /Cannot override VIEW_PRESERVES_CONTEXT=true/);
+});


### PR DESCRIPTION
@shajith @jish

The `VIEW_PRESERVES_CONTEXT` flag is global, which makes it difficult to upgrade a large application. This adds support for view classes to define a class-level `preservesContext` property that overrides the flag. It also adds a new value for the flag, "warn", which will warn for any view that _doesn't_ declare that it preserves context. If `VIEW_PRESERVES_CONTEXT` is `true`, it cannot be overridden.
