### PR TITLE
add CREATE_CHILD_VIEW flag

### DIFF
--- a/doc/create_child_view.md
+++ b/doc/create_child_view.md
@@ -1,0 +1,40 @@
+# createChildView
+
+In Ember 0.9, `Ember.View#createChildView` calls
+
+```javascript
+view = view.create(coreAttrs, attrs);
+```
+
+In Ember 1.0, it merges those "core" attributes into `attrs` and calls
+`create` with a single argument.
+
+Thus, if your `itemViewClass` class *expects* multiple arguments, it will cease
+to work in Ember 1.0.
+
+## Upgrade Guide
+
+Setting `ENV.CREATE_CHILD_VIEW` to `"warn"` will tell you where your app has
+child view classes that look like
+
+```javascript
+MyChildView = Ember.View.extend({
+  ...
+}).reopenClass({
+  create: function(coreAttrs, attrs) {
+    this._super(coreAttrs, attrs);
+
+    doSomethingWith(coreAttrs._parentView);
+    doSomethingElseWith(coreAttrs.templateData);
+  }
+});
+```
+
+At the `"warn"` level, those constructors will continue to receive two
+arguments, though the first one will be the union of the two. Identify the
+constructors that expect two arguments and change them to expect all attributes
+in a single, merged hash.
+
+After you have eliminated all warnings, you can set `ENV.CREATE_CHILD_VIEW` to
+`"1.0"`, which will cause `Ember.View#createChildView` to throw an exception
+(via `Ember.assert`) if your view constructor expects multiple arguments.

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1784,12 +1784,21 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     @test in createChildViews
   */
   createChildView: function(view, attrs) {
-    var coreAttrs, templateData;
+    var coreAttrs, templateData, createArity, op;
 
     if (Ember.View.detect(view)) {
       coreAttrs = { _parentView: this, templateData: get(this, 'templateData') };
 
       if (attrs) {
+        createArity = (view.create.base ? view.create.base.length : view.create.length);
+
+        if (createArity > 1) {
+          op = {warn: Ember.deprecate, '1.0': Ember.assert}[Ember.ENV.CREATE_CHILD_VIEW] || Ember.K;
+          op( 'Ember.View#createChildView will pass only one argument to ' + view + '.create in Ember 1.0' );
+        }
+
+        if (Ember.ENV.CREATE_CHILD_VIEW) { Ember.$.extend(coreAttrs, attrs); }
+
         view = view.create(coreAttrs, attrs);
       } else {
         view = view.create(coreAttrs);

--- a/packages/ember-views/tests/backports/create_child_view_test.js
+++ b/packages/ember-views/tests/backports/create_child_view_test.js
@@ -1,0 +1,109 @@
+var getPath = Ember.getPathWithoutDeprecation;
+
+var originalFlag, originalWarn, warnings;
+
+var TakesOneArgView = Ember.View.extend().reopenClass({
+  create: function(attrs) {
+    var instance = this._super.apply(this, arguments);
+    instance.set('createdWith', [].slice.call(arguments));
+    return instance;
+  }
+});
+
+var TakesTwoArgsView = Ember.View.extend().reopenClass({
+  create: function(coreAttrs, attrs) {
+    var instance = this._super.apply(this, arguments);
+    instance.set('createdWith', [].slice.call(arguments));
+    return instance;
+  }
+});
+
+module("Backported Ember.View#createChildView behavior", {
+  setup: function() {
+    originalFlag = Ember.ENV.CREATE_CHILD_VIEW;
+    originalWarn = Ember.Logger.warn;
+    warnings = [];
+    Ember.Logger.warn = function(msg) {
+      warnings.push(msg.replace("WARNING: ", ""));
+    };
+  },
+  teardown: function() {
+    Ember.ENV.CREATE_CHILD_VIEW = originalFlag;
+    Ember.Logger.warn = originalWarn;
+  }
+});
+
+// Ember.ENV.CREATE_CHILD_VIEW = null
+
+test("passes two arguments to create in 0.9 mode", function() {
+  Ember.ENV.CREATE_CHILD_VIEW = null;
+  var view = Ember.ContainerView.create().createChildView(TakesOneArgView, { food: 'ramen' });
+  equal(getPath(view, 'createdWith.length'), 2);
+});
+
+test("does not warn when create expects multiple arguments in 0.9 mode", function() {
+  Ember.ENV.CREATE_CHILD_VIEW = null;
+  var view = Ember.ContainerView.create().createChildView(TakesTwoArgsView, { food: 'ramen' });
+  equal(getPath(view, 'food'), 'ramen');
+  equal(warnings.length, 0);
+});
+
+// Ember.ENV.CREATE_CHILD_VIEW = "warn"
+
+test("passes two arguments to create in warn mode", function() {
+  Ember.ENV.CREATE_CHILD_VIEW = 'warn';
+  var view = Ember.ContainerView.create().createChildView(TakesOneArgView, { food: 'ramen' });
+  equal(getPath(view, 'createdWith.length'), 2);
+});
+
+test("pre-merges the second argument into the first in warn mode", function() {
+  Ember.ENV.CREATE_CHILD_VIEW = 'warn';
+  var view = Ember.ContainerView.create().createChildView(TakesOneArgView, { food: 'ramen' });
+  var firstArg = getPath(view, 'createdWith')[0];
+  equal(firstArg.food, 'ramen');
+  ok(firstArg._parentView);
+});
+
+test("does not warn when create expects only one argument in warn mode", function() {
+  Ember.ENV.CREATE_CHILD_VIEW = 'warn';
+  var view = Ember.ContainerView.create().createChildView(TakesOneArgView, { food: 'ramen' });
+  equal(getPath(view, 'food'), 'ramen');
+  equal(warnings.length, 0);
+});
+
+test("warns when create expects multiple arguments in warn mode", function() {
+  Ember.ENV.CREATE_CHILD_VIEW = 'warn';
+  var view = Ember.ContainerView.create().createChildView(TakesTwoArgsView, { food: 'ramen' });
+  equal(getPath(view, 'food'), 'ramen');
+  equal(warnings.length, 1);
+});
+
+// Ember.ENV.CREATE_CHILD_VIEW = "1.0"
+
+test("does not throw an error when create expects only one argument in 1.0 mode", function() {
+  Ember.ENV.CREATE_CHILD_VIEW = '1.0';
+  var view = Ember.ContainerView.create().createChildView(TakesOneArgView, { food: 'ramen' });
+  equal(getPath(view, 'food'), 'ramen');
+});
+
+test("throws an error when create expects multiple arguments in 1.0 mode", function() {
+  Ember.ENV.CREATE_CHILD_VIEW = '1.0';
+  var containerView = Ember.ContainerView.create();
+  raises(function() {
+    containerView.createChildView(TakesTwoArgsView, { food: 'ramen' });
+    new Ember.Binding('foo.value', 'bar.value').transform({ from: function() {}, to: function() {} });
+  }, /createChildView will pass only one argument.*in Ember 1.0/);
+});
+
+test("passes only one merged argument in 1.0 mode", function() {
+  Ember.ENV.CREATE_CHILD_VIEW = '1.0';
+  var view = Ember.ContainerView.create().createChildView(TakesOneArgView);
+  equal(getPath(view, 'createdWith.length'), 1);
+});
+
+test("it doesn't override templateData when merging in 1.0 mode", function() {
+  Ember.ENV.CREATE_CHILD_VIEW = '1.0';
+  var parentView = Ember.ContainerView.create({ templateData: { food: 'sushi '} });
+  var view = parentView.createChildView(TakesOneArgView, { templateData: { food: 'ramen' } });
+  equal(getPath(view, 'templateData.food'), 'ramen');
+});


### PR DESCRIPTION
@shajith @jish @chrsjxn

In Ember 0.9, `Ember.View#createChildView` calls

``` javascript
view = view.create(coreAttrs, attrs);
```

In Ember 1.0, it merges those "core" attributes into `attrs` and calls `create` with a single argument.

Thus, if your `itemViewClass` class _expects_ multiple arguments, it will cease to work in Ember 1.0.

Setting `ENV.CREATE_CHILD_VIEW` to `"warn"` will tell you where your app has child view classes that look like

``` javascript
MyChildView = Ember.View.extend({
  ...
}).reopenClass({
  create: function(coreAttrs, attrs) {
    this._super(coreAttrs, attrs);

    doSomethingWith(coreAttrs._parentView);
    doSomethingElseWith(coreAttrs.templateData);
  }
});
```

You will have to change those constructors to accept a single hash argument. The single hash will be the union of what used to be `coreAttrs` and `attrs`.

After you have eliminated all warnings, you can set `ENV.CREATE_CHILD_VIEW` to `"1.0"`, which will cause `Ember.View#createChildView` to throw an exception (via `Ember.assert`) if your view constructor expects multiple arguments.
