### PR TITLE
[WIP] Make template context proxy.

### DIFF
--- a/packages/ember-metal/lib/watching.js
+++ b/packages/ember-metal/lib/watching.js
@@ -436,6 +436,11 @@ Ember.watch = function(obj, keyName) {
   // activate watching first time
   if (!watching[keyName]) {
     watching[keyName] = 1;
+
+    if ('function' === typeof obj.willWatchProperty) {
+      obj.willWatchProperty(keyName);
+    }
+
     if (isKeyName(keyName)) {
       desc = m.descs[keyName];
       desc = desc ? desc.watched : WATCHED_PROPERTY;
@@ -465,6 +470,11 @@ Ember.unwatch = function(obj, keyName) {
   keyName = normalizePath(keyName);
   if (watching[keyName] === 1) {
     watching[keyName] = 0;
+
+    if ('function' === typeof obj.didUnwatchProperty) {
+      obj.didUnwatchProperty(keyName);
+    }
+
     if (isKeyName(keyName)) {
       desc = meta(obj).descs[keyName];
       desc = desc ? desc.unwatched : SIMPLE_PROPERTY;

--- a/packages/ember-views/lib/main.js
+++ b/packages/ember-views/lib/main.js
@@ -11,3 +11,4 @@ require("ember-runtime");
 require("ember-views/core");
 require("ember-views/system");
 require("ember-views/views");
+require("ember-views/template_context_proxy");

--- a/packages/ember-views/lib/template_context_proxy.js
+++ b/packages/ember-views/lib/template_context_proxy.js
@@ -1,8 +1,41 @@
-var get = Ember.get, set = Ember.set;
+var get = Ember.get, set = Ember.set,
+    addBeforeObserver = Ember.addBeforeObserver,
+    addObserver = Ember.addObserver,
+    removeBeforeObserver = Ember.removeBeforeObserver,
+    removeObserver = Ember.removeObserver,
+    propertyWillChange = Ember.propertyWillChange,
+    propertyDidChange = Ember.propertyDidChange,
+    meta = Ember.meta,
+    defineProperty = Ember.defineProperty;
+
+function viewPropertyWillChange(content, viewKey) {
+  var key = viewKey.slice(5); // remove "view."
+  if (key in this) { return; }  // if shadowed in proxy
+  propertyWillChange(this, key);
+}
+
+function viewPropertyDidChange(content, viewKey) {
+  var key = viewKey.slice(5); // remove "view."
+  if (key in this) { return; } // if shadowed in proxy
+  propertyDidChange(this, key);
+}
+
 
 Ember.TemplateContextProxy = Ember.Object.extend({
   parentView: null,
   view: null,
+
+  willWatchProperty: function (key) {
+    var viewKey = 'view.' + key;
+    addBeforeObserver(this, viewKey, null, viewPropertyWillChange);
+    addObserver(this, viewKey, null, viewPropertyDidChange);
+  },
+
+  didUnwatchProperty: function (key) {
+    var viewKey = 'view.' + key;
+    removeBeforeObserver(this, viewKey, null, viewPropertyWillChange);
+    removeObserver(this, viewKey, null, viewPropertyDidChange);
+  },
 
   unknownProperty: function(keyName) {
     var view = get(this, 'view'),
@@ -11,5 +44,14 @@ Ember.TemplateContextProxy = Ember.Object.extend({
     Ember.deprecate(view.constructor + " accesses " + keyName + " directly from " + templateName + ".", false);
 
     return view.get(keyName);
+  },
+
+  setUnknownProperty: function(keyName, value) {
+    var view = get(this, 'view'),
+        templateName = get(view, 'templateName');
+
+    Ember.deprecate(view.constructor + " sets " + keyName + " directly from " + templateName + ".", false);
+
+    return set(view, keyName, value);
   }
 });

--- a/packages/ember-views/lib/template_context_proxy.js
+++ b/packages/ember-views/lib/template_context_proxy.js
@@ -1,0 +1,15 @@
+var get = Ember.get, set = Ember.set;
+
+Ember.TemplateContextProxy = Ember.Object.extend({
+  parentView: null,
+  view: null,
+
+  unknownProperty: function(keyName) {
+    var view = get(this, 'view'),
+        templateName = get(view, 'templateName');
+
+    Ember.deprecate(view.constructor + " accesses " + keyName + " directly from " + templateName + ".", false);
+
+    return view.get(keyName);
+  }
+});

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -565,7 +565,8 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     var globalSetting = Ember.VIEW_PRESERVES_CONTEXT,
         classPreference = this.constructor.preservesContext,
         preservesContext,
-        parentView;
+        parentView = get(this, '_parentView'),
+        templateContextProxy;
 
     if (globalSetting === true) {
       if (classPreference === false) {
@@ -580,13 +581,18 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     }
 
     if (preservesContext) {
-      parentView = get(this, '_parentView');
+      // Follow  the Ember 1.0.0 strategy
       if (parentView) {
         return get(parentView, '_templateContext');
       }
     }
 
-    return this;
+    templateContextProxy = Ember.TemplateContextProxy.create({
+      parentView: get(this, '_parentView'),
+      view: this
+    });
+
+    return templateContextProxy;
   }).cacheable(),
 
   /**


### PR DESCRIPTION
This is a work in progress that would generate warnings if a view's properties were accessed without `view.` when `VIEW_PRESERVES_CONTEXT` is enabled (or set to 'warn').

The majority of tests pass at this point.  The remaining issue relates to views that define their own `contentBinding`.  

I plan to continue working on this, but figured it makes sense to get the code out there for a bit of a sanity check at this point.
