### PR TITLE
use trySet in bindings

### DIFF
--- a/packages/ember-metal/lib/binding.js
+++ b/packages/ember-metal/lib/binding.js
@@ -5,7 +5,7 @@
 // ==========================================================================
 
 require('ember-metal/core'); // Ember.Logger
-require('ember-metal/accessors'); // get, getPath, setPath, trySetPath
+require('ember-metal/accessors'); // get, getPath, setPath, trySet
 require('ember-metal/utils'); // guidFor, isArray, meta
 require('ember-metal/observer'); // addObserver, removeObserver
 require('ember-metal/run_loop'); // Ember.run.schedule
@@ -568,10 +568,10 @@ Binding.prototype = /** @scope Ember.Binding.prototype */ {
         Ember.Logger.log(' ', this.toString(), '->', fromValue, obj);
       }
       if (this._oneWay) {
-        Ember.trySetPath(Ember.isGlobalPath(toPath) ? window : obj, toPath, fromValue);
+        Ember.trySet(Ember.isGlobalPath(toPath) ? window : obj, toPath, fromValue);
       } else {
         Ember._suspendObserver(obj, toPath, this, this.toDidChange, function () {
-          Ember.trySetPath(Ember.isGlobalPath(toPath) ? window : obj, toPath, fromValue);
+          Ember.trySet(Ember.isGlobalPath(toPath) ? window : obj, toPath, fromValue);
         });
       }
     // if we're synchronizing *to* the remote object
@@ -581,7 +581,7 @@ Binding.prototype = /** @scope Ember.Binding.prototype */ {
         Ember.Logger.log(' ', this.toString(), '<-', toValue, obj);
       }
       Ember._suspendObserver(obj, fromPath, this, this.fromDidChange, function () {
-        Ember.trySetPath(Ember.isGlobalPath(fromPath) ? window : obj, fromPath, toValue);
+        Ember.trySet(Ember.isGlobalPath(fromPath) ? window : obj, fromPath, toValue);
       });
     }
   }

--- a/packages/ember-metal/tests/accessors/setPath_test.js
+++ b/packages/ember-metal/tests/accessors/setPath_test.js
@@ -167,6 +167,6 @@ test('[obj, foo.baz.bat] -> EXCEPTION', function() {
 });
 
 test('[obj, foo.baz.bat] -> EXCEPTION', function() {
-  Ember.trySetPath(obj, 'foo.baz.bat', "BAM");
+  Ember.trySet(obj, 'foo.baz.bat', "BAM");
   ok(true, "does not raise");
 });

--- a/packages/ember-metal/tests/backports/accessors_test.js
+++ b/packages/ember-metal/tests/backports/accessors_test.js
@@ -28,6 +28,14 @@ test("get does not warn on keys with dots in 0.9 mode", function() {
   equal(warnings.length, 0);
 });
 
+test("trySet exists and follows paths in 0.9 mode", function() {
+  Ember.ENV.ACCESSORS = null;
+  var o = { foo: {bar: 'baz'} };
+  Ember.trySet(o, 'foo.bar', 'qux');
+  equal(o.foo.bar, 'qux');
+  equal(warnings.length, 0);
+});
+
 // Ember.ENV.ACCESSORS = "0.9-dotted-properties"
 
 test("get warns with dots in key name on the 0.9 mode with warnings", function() {
@@ -44,6 +52,14 @@ test("set warns with dots in key name on the 0.9 mode with warnings", function()
   Ember.set(o, 'foo.bar', 'baz');
   equal(warnings.length, 1);
   matches(warnings[0], "The behavior of `set` has changed in Ember 1.0. It will no longer support keys with periods in them.");
+});
+
+test("trySet exists and follows paths in 0.9-dotted-properties mode", function() {
+  Ember.ENV.ACCESSORS = '0.9-dotted-properties';
+  var o = { foo: {bar: 'baz'} };
+  Ember.trySet(o, 'foo.bar', 'qux');
+  equal(o.foo.bar, 'qux');
+  equal(warnings.length, 0);
 });
 
 // Ember.ENV.ACCESSORS = "1.0-no-warn"


### PR DESCRIPTION
Using `trySetPath` in framework code will raise deprecation warnings in 1.0 mode. Instead, change `trySetPath` uses to `trySet` and ensure that works as expected on all ACCESSORS levels.

/cc @shajith @chrsjxn
