### PR TITLE
Use Ember.Handlebars.get internally

### DIFF
--- a/packages/ember-handlebars/lib/controls/button.js
+++ b/packages/ember-handlebars/lib/controls/button.js
@@ -29,7 +29,7 @@ Ember.Button = Ember.View.extend(Ember.TargetActionSupport, {
 
     if (typeof target !== 'string') { return target; }
 
-    return Ember.Handlebars.getPath(root, target, { data: data });
+    return Ember.Handlebars.get(root, target, { data: data });
   }).property('target').cacheable(),
 
   // Defaults to 'button' if tagName is 'input' or 'button'

--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -9,7 +9,7 @@ require('ember-handlebars/views/handlebars_bound_view');
 require('ember-handlebars/views/metamorph_view');
 
 var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
-var getPath = Ember.Handlebars.getPath, normalizePath = Ember.Handlebars.normalizePath;
+var getPath = Ember.Handlebars.get, normalizePath = Ember.Handlebars.normalizePath;
 var forEach = Ember.ArrayUtils.forEach;
 
 var EmberHandlebars = Ember.Handlebars, helpers = EmberHandlebars.helpers;

--- a/packages/ember-handlebars/lib/helpers/collection.js
+++ b/packages/ember-handlebars/lib/helpers/collection.js
@@ -9,7 +9,7 @@
 require('ember-handlebars');
 require('ember-handlebars/helpers/view');
 
-var get = Ember.get, getPath = Ember.Handlebars.getPath, fmt = Ember.String.fmt;
+var get = Ember.get, getPath = Ember.Handlebars.get, fmt = Ember.String.fmt;
 
 /**
   `{{collection}}` is a `Ember.Handlebars` helper for adding instances of
@@ -111,7 +111,7 @@ var get = Ember.get, getPath = Ember.Handlebars.getPath, fmt = Ember.String.fmt;
         <p class="ember-view greeting">Howdy Mary</p>
         <p class="ember-view greeting">Howdy Sara</p>
       </div>
-  
+
   @name Handlebars.helpers.collection
   @param {String} path
   @param {Hash} options

--- a/packages/ember-handlebars/lib/helpers/unbound.js
+++ b/packages/ember-handlebars/lib/helpers/unbound.js
@@ -7,7 +7,7 @@
 
 require('ember-handlebars/ext');
 
-var getPath = Ember.Handlebars.getPath;
+var getPath = Ember.Handlebars.get;
 
 /**
   `unbound` allows you to output a property without binding. *Important:* The

--- a/packages/ember-handlebars/lib/views/handlebars_bound_view.js
+++ b/packages/ember-handlebars/lib/views/handlebars_bound_view.js
@@ -5,7 +5,7 @@
 // ==========================================================================
 /*globals Handlebars */
 
-var get = Ember.get, set = Ember.set, getPath = Ember.Handlebars.getPath;
+var get = Ember.get, set = Ember.set, getPath = Ember.Handlebars.get;
 
 require('ember-views/views/view');
 require('ember-handlebars/views/metamorph_view');


### PR DESCRIPTION
@shajith @chrsjxn

`Ember.Handlebars.getPath` emits deprecation warnings if `ACCESSORS` is set to `1.0`. `Ember.Handlebars.get` is new and always has 1.0 semantics. (It uses `Ember.getPathWithoutDeprecation`). Thus, we can always use the `.get` version safely and avoid the warnings.
