### PR TITLE
Fix VIEW_PRESERVES_CONTEXT `warn` setting

### DIFF
--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -147,7 +147,7 @@ Ember.CP_DEFAULT_CACHEABLE = !!Ember.ENV.CP_DEFAULT_CACHEABLE;
         {{/view}}
       {{/each}}
 */
-Ember.VIEW_PRESERVES_CONTEXT = !!Ember.ENV.VIEW_PRESERVES_CONTEXT;
+Ember.VIEW_PRESERVES_CONTEXT = Ember.ENV.VIEW_PRESERVES_CONTEXT;
 
 /**
   Empty function.  Useful for some operations.


### PR DESCRIPTION
`ember-views/lib/views/view.js` uses Ember.VIEW_PRESERVES_CONTEXT
to determine if it should warn, but this line of code squashes
the `warn` setting to true.
