### PR TITLE
Ember.Handlebars.precompile supports knownHelpers

### DIFF
--- a/packages/ember-handlebars/lib/ext.js
+++ b/packages/ember-handlebars/lib/ext.js
@@ -95,9 +95,11 @@ Ember.Handlebars.Compiler.prototype.mustache = function(mustache) {
 
   @param {String} string The template to precompile
 */
-Ember.Handlebars.precompile = function(string) {
+Ember.Handlebars.precompile = function(string, options) {
   var ast = Handlebars.parse(string);
-  var options = { data: true, stringParams: true };
+  options = options || {};
+  options.data = true;
+  options.stringParams = true;
   var environment = new Ember.Handlebars.Compiler().compile(ast, options);
   return new Ember.Handlebars.JavaScriptCompiler().compile(environment, options, undefined, true);
 };

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -1648,6 +1648,13 @@ test("should work with precompiled templates", function() {
   equal(view.$().text(), "updated", "the precompiled template was updated");
 });
 
+test("should understand knownHelpers", function() {
+  var knownHelpers = { highlight: true },
+      templateString = Ember.Handlebars.precompile("{{highlight foo}}", { knownHelpers: knownHelpers });
+
+  ok(!/helperMissing/.test(templateString), "Expected " + templateString + " not to use helperMissing.");
+});
+
 test("should expose a controller keyword when present on the view", function() {
   var templateString = "{{controller.foo}}{{#view}}{{controller.baz}}{{/view}}";
   view = Ember.View.create({


### PR DESCRIPTION
:fire: @zendesk/browncoats @shajith @chrsjxn

`Handlebars.precompile` supports a second `options` argument. Sadly, `Ember.Handlebars.precompile` did not; it simply defined its own `options` and passed them in. This adds support for passing in that second argument. Specifically, the compiling client can pass in `knownHelpers` so that Handlebars won't use `helperMissing` to do all helper lookups.
