### PR TITLE
Don't try to fire actions that don't exist

### DIFF
--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -135,11 +135,14 @@ Ember.EventDispatcher = Ember.Object.extend(
 
     rootElement.delegate('[data-ember-action]', event + '.ember', function(evt) {
       var actionId = Ember.$(evt.currentTarget).attr('data-ember-action'),
-          action   = Ember.Handlebars.ActionHelper.registeredActions[actionId],
-          handler  = action.handler;
+          action   = Ember.Handlebars.ActionHelper.registeredActions[actionId];
 
-      if (action.eventName === eventName) {
-        return handler(evt);
+      // Fix from https://github.com/emberjs/ember.js/commit/aafb5eb5693dccf04dd0951385b4c6bb6db7ae46
+      // We have to check for action here since in some cases, jQuery will trigger
+      // an event on `removeChild` (i.e. focusout) after we've already torn down the
+      // action handlers for the view.
+      if (action && action.eventName === eventName) {
+        return action.handler(evt);
       }
     });
   },


### PR DESCRIPTION
Those happen frequently in Lotus, for example sometimes when closing ticket tabs.

![](https://f.cloud.github.com/assets/279376/1476890/781eb5be-4651-11e3-8848-a2d44c9a36be.png)

Fix ported from https://github.com/emberjs/ember.js/commit/aafb5eb5693dccf04dd0951385b4c6bb6db7ae46.

Ember 1.0 has a much complex way of fixing the problem, but the one above was their first solution I think, and should be good enough for us while we migrate to Ember 1.0.

/cc @jamesarosen @shajith @kruppel
