### PR TITLE
Backport Ember.isEmpty

### DIFF
--- a/doc/is_empty.md
+++ b/doc/is_empty.md
@@ -1,0 +1,8 @@
+# Ember.empty
+
+Ember 1 deprecates `Ember.empty` in favor of `Ember.isEmpty`. This introduces a flag,
+`EMBER_EMPTY`, with two values:
+
+
+ * `null` (the default) -- `Ember.empty` and `Ember.isEmpty` both work without warning
+ * `"1.0"` -- `Ember.empty` continues to work, but emits warnings

--- a/packages/ember-runtime/lib/core.js
+++ b/packages/ember-runtime/lib/core.js
@@ -114,9 +114,14 @@ Ember.none = function(obj) {
   @param {Object} obj Value to test
   @returns {Boolean}
 */
-Ember.empty = function(obj) {
+Ember.isEmpty = function(obj) {
   return obj === null || obj === undefined || (obj.length === 0 && typeof obj !== 'function');
 };
+
+Ember.empty = function(obj) {
+  Ember.warn('Ember.empty is deprecated. Please use Ember.isEmpty instead.', Ember.ENV.EMBER_EMPTY == null);
+  return Ember.isEmpty(obj);
+}
 
 /**
  This will compare two javascript values of possibly different types.


### PR DESCRIPTION
@shajith @ebryn

Ember 1 deprecates `Ember.empty` in favor of `Ember.isEmpty`. This introduces a flag,
`EMBER_EMPTY`, with two values:
- `null` (the default) -- `Ember.empty` and `Ember.isEmpty` both work without warning
- `"1.0"` -- `Ember.empty` continues to work, but emits warnings
