### PR TITLE
_templateContext: returns controller if available when preserving context

### DIFF
--- a/doc/view_preserves_context.md
+++ b/doc/view_preserves_context.md
@@ -2,8 +2,9 @@
 
 In Ember 0.9.7.1, the context for a view's template is the view itself.
 
-In Ember 1.0, it is the parent view's context, which, if you follow it all the
-way up the chain, is usually a controller.
+In Ember 1, it is the view's controllor or, if that doesn't exist, the
+parent view's context, which, if you follow it all the way up the chain,
+is usually a controller.
 
 Ember 0.9.8.1 introduced a global flag, `VIEW_PRESERVES_CONTEXT`, which allows
 application developers to select which behavior they want. Unfortunately, a
@@ -15,6 +16,10 @@ Ember 0.9.9 adds support for view classes to define a class-level
 for the flag, "warn", which will warn for any view that *doesn't* declare that
 it preserves context. If `VIEW_PRESERVES_CONTEXT` is `true`, it cannot be
 overridden.
+
+Ember 0.9.9 also defaults the template context to the view's `controller`,
+if present (and if `VIEW_PRESERVES_CONTEXT` is `"warn"` or `true`), which is
+the behavior of Ember 1.
 
 ## Summary
 

--- a/packages/ember-handlebars/tests/backports/context_preservation_test.js
+++ b/packages/ember-handlebars/tests/backports/context_preservation_test.js
@@ -83,7 +83,15 @@ test("allows views to specify that they preserve context on 'warn' level", funct
   equal(appendView(true).$().text(), "parent view value");
 });
 
-test("preserves context on true level", function() {
+test("checks for a controller on true level", function() {
+  Ember.VIEW_PRESERVES_CONTEXT = true;
+  ContextPreservationTests.ChildView.reopen({
+    controller: { key: 'controller value' }
+  });
+  equal(appendView(undefined).$().text(), 'controller value');
+});
+
+test("falls back to the parent view on true level", function() {
   Ember.VIEW_PRESERVES_CONTEXT = true;
   equal(appendView(undefined).$().text(), 'parent view value');
 });

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -1772,11 +1772,12 @@ test("Ember.Button targets should respect keywords", function() {
   Ember.TESTING_DEPRECATION = true;
 
   try {
-    var templateString = '{{#with anObject}}{{view Ember.Button target="controller.foo"}}{{/with}}';
+    var templateString = '{{#with anObject}}{{view Ember.Button target="view.myController.foo"}}{{/with}}';
+
     view = Ember.View.create({
       template: Ember.Handlebars.compile(templateString),
       anObject: {},
-      controller: {
+      myController: {
         foo: "bar"
       }
     });
@@ -1921,7 +1922,7 @@ test("bindings should respect keywords", function() {
   view = Ember.View.create({
     museumOpen: true,
 
-    controller: {
+    myController: {
       museumDetails: Ember.Object.create({
         name: "SFMoMA",
         price: 20
@@ -1932,7 +1933,7 @@ test("bindings should respect keywords", function() {
       template: Ember.Handlebars.compile('Name: {{view.name}} Price: ${{view.dollars}}')
     }),
 
-    template: Ember.Handlebars.compile('{{#if museumOpen}}{{view museumView nameBinding="controller.museumDetails.name" dollarsBinding="controller.museumDetails.price"}}{{/if}}')
+    template: Ember.Handlebars.compile('{{#if museumOpen}}{{view museumView nameBinding="view.myController.museumDetails.name" dollarsBinding="myController.museumDetails.price"}}{{/if}}')
   });
 
   Ember.run(function() {

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -565,7 +565,8 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     var globalSetting = Ember.VIEW_PRESERVES_CONTEXT,
         classPreference = this.constructor.preservesContext,
         preservesContext,
-        parentView;
+        parentView,
+        controller;
 
     if (globalSetting === true) {
       if (classPreference === false) {
@@ -580,10 +581,11 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     }
 
     if (preservesContext) {
+      controller = get(this, 'controller');
+      if (controller) { return controller; }
+
       parentView = get(this, '_parentView');
-      if (parentView) {
-        return get(parentView, '_templateContext');
-      }
+      if (parentView) { return get(parentView, '_templateContext'); }
     }
 
     return this;


### PR DESCRIPTION
In Ember 1.0, a view's template context is
1. `view.controller` if that exists
2. `view.parentView.context` otherwise

We back-ported (b), but not (a). This adds the check for `controller`.

This breaks certain tests. Specifically, there are Handlebars tests that create view that has a controller property, which would change the context of the view's template. To fix these tests, I changed `controller` to `myController`.

One of the tests still fails when `VIEW_PRESERVES_CONTEXT` is `true` because the property is relative to the view, but accessed without the `view.` prefix. The test name ends in "respects keywords", which makes me believe the test _should_ have `view.`, regardless of the controller changes.

@ebryn @shajith @jish
