### PR TITLE
Ember uses isEmpty, not Empty

### DIFF
--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -24,7 +24,7 @@ if ('undefined' === typeof Ember) {
       // any other return value (including void) will pass.
       Ember.assert('a passed record must have a firstName', function() {
         if (obj instanceof Ember.Record) {
-          return !Ember.empty(obj.firstName);
+          return !Ember.isEmpty(obj.firstName);
         }
       });
 

--- a/packages/ember-runtime/lib/core.js
+++ b/packages/ember-runtime/lib/core.js
@@ -103,13 +103,13 @@ Ember.none = function(obj) {
   Constrains the rules on `Ember.none` by returning false for empty
   string and empty arrays.
 
-      Ember.empty();               => true
-      Ember.empty(null);           => true
-      Ember.empty(undefined);      => true
-      Ember.empty('');             => true
-      Ember.empty([]);             => true
-      Ember.empty('tobias fünke'); => false
-      Ember.empty([0,1,2]);        => false
+      Ember.isEmpty();               => true
+      Ember.isEmpty(null);           => true
+      Ember.isEmpty(undefined);      => true
+      Ember.isEmpty('');             => true
+      Ember.isEmpty([]);             => true
+      Ember.isEmpty('tobias fünke'); => false
+      Ember.isEmpty([0,1,2]);        => false
 
   @param {Object} obj Value to test
   @returns {Boolean}

--- a/packages/ember-runtime/tests/core/empty_test.js
+++ b/packages/ember-runtime/tests/core/empty_test.js
@@ -5,21 +5,21 @@
 // License:   Licensed under MIT license (see license.js)
 // ==========================================================================
 
-module("Ember.empty");
+module("Ember.isEmpty");
 
-test("Ember.empty", function() {
+test("Ember.isEmpty", function() {
   var string = "string", fn = function() {},
       object = {length: 0};
 
-  equal(true,  Ember.empty(null),      "for null");
-  equal(true,  Ember.empty(undefined), "for undefined");
-  equal(true,  Ember.empty(""),        "for an empty String");
-  equal(false, Ember.empty(true),      "for true");
-  equal(false, Ember.empty(false),     "for false");
-  equal(false, Ember.empty(string),    "for a String");
-  equal(false, Ember.empty(fn),        "for a Function");
-  equal(false, Ember.empty(0),         "for 0");
-  equal(true,  Ember.empty([]),        "for an empty Array");
-  equal(false, Ember.empty({}),        "for an empty Object");
-  equal(true,  Ember.empty(object),     "for an Object that has zero 'length'");
+  equal(true,  Ember.isEmpty(null),      "for null");
+  equal(true,  Ember.isEmpty(undefined), "for undefined");
+  equal(true,  Ember.isEmpty(""),        "for an empty String");
+  equal(false, Ember.isEmpty(true),      "for true");
+  equal(false, Ember.isEmpty(false),     "for false");
+  equal(false, Ember.isEmpty(string),    "for a String");
+  equal(false, Ember.isEmpty(fn),        "for a Function");
+  equal(false, Ember.isEmpty(0),         "for 0");
+  equal(true,  Ember.isEmpty([]),        "for an empty Array");
+  equal(false, Ember.isEmpty({}),        "for an empty Object");
+  equal(true,  Ember.isEmpty(object),     "for an Object that has zero 'length'");
 });

--- a/packages/ember-states/lib/state_manager.js
+++ b/packages/ember-states/lib/state_manager.js
@@ -450,7 +450,7 @@ Ember.StateManager = Ember.State.extend(
     // 3. Map provided path to context objects and send
     //    appropriate setupControllers events
 
-    if (Ember.empty(name)) { return; }
+    if (Ember.isEmpty(name)) { return; }
 
     var segments;
 


### PR DESCRIPTION
@ebryn @kruppel

We backported `Ember.isEmpty` from Ember 1 and deprecated `Ember.empty` in 19de636acfb97b0644db234ae251da976accc921, but didn't change the Ember framework code to take advantage of that.
