### PR TITLE
ContainerView acts like an Array

### DIFF
--- a/doc/enumerable_container_view.md
+++ b/doc/enumerable_container_view.md
@@ -1,0 +1,19 @@
+# ContainerView as Array
+
+In Ember 0.9, the standard way to manipulate an `Ember.ContainerView` is
+
+```js
+someContainerView
+  .get('childViews')
+  .pushObject(SomeChildView.create());
+```
+
+In Ember 1, mutating `childViews` from the outside is deprecated. Insted,
+the `ContainerView` itself acts like an array:
+
+```js
+someContainerView
+  .pushObject(SomeChildView.create());
+```
+
+This project backports the acts-as-array behavior from Ember 1.

--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -6,8 +6,11 @@
 // ==========================================================================
 
 require('ember-views/views/view');
-var get = Ember.get, set = Ember.set, meta = Ember.meta;
-var forEach = Ember.ArrayUtils.forEach;
+var get = Ember.get,
+    getPath = Ember.getPathWithoutDeprecation,
+    set = Ember.set,
+    meta = Ember.meta,
+    forEach = Ember.ArrayUtils.forEach;
 
 var childViewsProperty = Ember.computed(function() {
   return get(this, '_childViews');
@@ -205,7 +208,7 @@ var childViewsProperty = Ember.computed(function() {
   @extends Ember.View
 */
 
-Ember.ContainerView = Ember.View.extend({
+Ember.ContainerView = Ember.View.extend(Ember.MutableArray, {
 
   init: function() {
     var childViews = get(this, 'childViews');
@@ -266,6 +269,22 @@ Ember.ContainerView = Ember.View.extend({
     });
 
     this._super();
+  },
+
+  // Act as a proxy for its childViews:
+  length: Ember.computed(function() {
+    return getPath(this, 'childViews.length');
+  }).property('childViews.lengt').cacheable(),
+
+  objectAt: function(idx) {
+    var childViews = get(this, 'childViews');
+    if (childViews === null || childViews === undefined) { return undefined; }
+    return childViews.objectAt(idx);
+  },
+
+  replace: function() {
+    var array = this.get('childViews');
+    return array.replace.apply(array, arguments);
   },
 
   /**

--- a/packages/ember-views/tests/backports/enumerable_container_view_test.js
+++ b/packages/ember-views/tests/backports/enumerable_container_view_test.js
@@ -1,0 +1,29 @@
+var get = Ember.get, getPath = Ember.getPath, set = Ember.set;
+
+var container;
+
+module("ember-views/views/backports/enumerable_container_view_test", {
+  setup: function() {
+    container = Ember.ContainerView.create({
+      childViews: ['aChildView'],
+      aChildView: Ember.View.extend({ isAChild: true })
+    });
+
+    Ember.run(container, container.appendTo, '#qunit-fixture');
+  },
+
+  teardown: function() {
+    Ember.run(container, container.destroy);
+  }
+});
+
+test("supports indexing directly", function() {
+  equal(container.objectAt(0), get(container, 'aChildView'));
+});
+
+test("supports pushing children directly", function() {
+  container.pushObject(Ember.View.create({
+    isAnotherChild: true
+  }));
+  equal(getPath(container, 'childViews.length'), 2);
+});


### PR DESCRIPTION
Backported functionality from Ember1, but didn't backport warnings or add a flag as that required larger changes to the class.

@ebryn @shajith @vcekov
